### PR TITLE
Check for iRODS env variable

### DIFF
--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -27,7 +27,7 @@ else
 fi
 
 #check if there is an exclusion file, if so change the parameter
-if [ -f "/data/BioGrid/NGSlab/sample_sheets/${irods_input_sequencing__run_id}.exclude" ]
+if [ ! -z "${irods_input_sequencing__run_id}" ] && [ -f "/data/BioGrid/NGSlab/sample_sheets/${irods_input_sequencing__run_id}.exclude" ]
 then
   EXCLUSION_FILE="/data/BioGrid/NGSlab/sample_sheets/${irods_input_sequencing__run_id}.exclude"
 fi


### PR DESCRIPTION
The env variable irods_input_sequencing__run_id dus not always exist. If it does not the exclusion file cannot be found.