### PR TITLE
Large file issues

### DIFF
--- a/bin/rules/identify_species.smk
+++ b/bin/rules/identify_species.smk
@@ -29,6 +29,7 @@ rule identify_species_reads:
             --report {output.kraken2_kreport} \
             --gzip-compressed \
             --paired \
+            --output - \
             {input.r1} {input.r2}  &> {log} 
 
         bracken -d {params.kraken_db} \

--- a/config/pipeline_parameters.yaml
+++ b/config/pipeline_parameters.yaml
@@ -15,7 +15,7 @@ mem_gb:
     trimmomatic: 12
     picard: 12
     spades: 100
-    pileup: 6
+    pileup: 32
     multiqc: 8
     checkm: 12
     quast: 8

--- a/envs/scaffold_analyses.yaml
+++ b/envs/scaffold_analyses.yaml
@@ -1,7 +1,7 @@
 name: scaffold_analyses
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - nodefaults
 dependencies:
     - samtools==1.9
@@ -10,4 +10,5 @@ dependencies:
     - picard==2.26.0
     - r-base # r-base is sometimes required for picard to run. this isn't listed in the picard dependency list.
     - openjdk
+    - python=3 # without this, the recipe resolves to python 1.6 which might lead to strange bugs
 


### PR DESCRIPTION
Resolve some issues @KHajji reported while working with large fastq files:
- out of memory error for sortbyname.sh: increase mem limit
- disable kraken2 output per read to prevent large files

Also noticed python 1.6 was installed in the bbmap conda env, which is forced to python 3 now 